### PR TITLE
fix(unready-endpoints): use publishNotReadyAddresses

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  * Allow setting pod security context when deploying with Helm
  * Use [distroless](https://github.com/GoogleContainerTools/distroless) as base image for orchestrator container
  * Use networking.k8s.io/v1 instead of extensions/v1beta1 for ingress
+ * Use `Service.spec.publishNotReadyAddresses` instead of `service.alpha.kubernetes.io/tolerate-unready-endpoints`
 ### Removed
 ### Fixed
 

--- a/deploy/charts/mysql-operator/templates/orc-service.yaml
+++ b/deploy/charts/mysql-operator/templates/orc-service.yaml
@@ -15,10 +15,10 @@ metadata:
     chart: {{ $chart }}
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
   type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
   ports:
   - name: web
     port: 80

--- a/deploy/charts/mysql-operator/templates/statefulset.yaml
+++ b/deploy/charts/mysql-operator/templates/statefulset.yaml
@@ -47,7 +47,7 @@ spec:
           args:
             - --leader-election-namespace={{ .Release.Namespace }}
             # connect to orchestrator on localhost
-            - --orchestrator-uri=http://{{ template "mysql-operator.fullname" . }}.{{ .Release.Namespace }}/api
+            - --orchestrator-uri=http://{{ template "mysql-operator.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.orchestrator.service.port }}/api
             {{- if .Values.sidecarImage }}
             - --sidecar-image={{ .Values.sidecarImage }}
             {{- end -}}


### PR DESCRIPTION
The annotation `service.alpha.kubernetes.io/tolerate-unready-endpoints` is deprecated.  Users should use Service.spec.publishNotReadyAddresses instead.

link: https://github.com/kubernetes/kubernetes/pull/63742

Signed-off-by: cndoit18 <cndoit18@outlook.com>

---
 - [x] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
