### PR TITLE
It's not standard, it's STANDARD.

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -149,7 +149,7 @@ data:
   # Optional, the AWS region to connect
   # AWS_REGION: us-east1
   # Optional, specify the storage class
-  # AWS_STORAGE_CLASS: standard
+  # AWS_STORAGE_CLASS: STANDARD
   # Optional, canned ACL to use
   # AWS_ACL:
   # Optional, the S3 provider to use (default: AWS)

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -32,7 +32,7 @@ data:
   # Optional, the AWS region to connect
   # AWS_REGION: us-east1
   # Optional, specify the storage class
-  # AWS_STORAGE_CLASS: standard
+  # AWS_STORAGE_CLASS: STANDARD
   # Optional, canned ACL to use
   # AWS_ACL:
   # Optional, the S3 provider to use (default: AWS)


### PR DESCRIPTION
It's not standard, it's STANDARD.
If you use standard, you will get the following error.
* Post request rcat error: multipart upload failed to initialise: InvalidStorageClass: The storage class you specified is not valid.
