### PR TITLE
activate env auth for irsa

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 ### Added
-  * If you want to save mysql backup to AWS S3, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` were the only options, but now you can use `AWS_SESSION_TOKEN`.
+  * If you want to save mysql backup to AWS S3, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` were the only options, but now you can use `AWS_SESSION_TOKEN` or `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE`
  * Add `orchestrator.persistence.fsGroupWorkaroundEnabled` for persistent volume
    provisioners wich don't support fsGroup in security context (fixes #615)
  * Add `appSecretLabels`, `appSecretAnnotations`, `backupSecretLabels`, `backupSecretAnnotations` to provide 

--- a/images/mysql-operator-sidecar-5.7/rootfs/usr/local/bin/docker-entrypoint.sh
+++ b/images/mysql-operator-sidecar-5.7/rootfs/usr/local/bin/docker-entrypoint.sh
@@ -16,7 +16,7 @@ impersonate = ${GDRIVE_IMPERSONATOR}
 
 [s3]
 type = s3
-env_auth = false
+env_auth = true
 provider = ${S3_PROVIDER:-"AWS"}
 access_key_id = ${AWS_ACCESS_KEY_ID}
 secret_access_key = ${AWS_SECRET_ACCESS_KEY:-$AWS_SECRET_KEY}


### PR DESCRIPTION
In the case of irsa, you need to authenticate with AWS_WEB_IDENTITY_TOKEN_FILE and AWS_ROLE_ARN instead of session_token.

```sh
AWS_ROLE_ARN=arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE_NAME>
AWS_WEB_IDENTITY_TOKEN_FILE=/var/run/secrets/eks.amazonaws.com/serviceaccount/token
```

https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html#pod-configuration

In the case of IRSA, it was necessary to use `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN` for authentication instead of `AWS_SESSION_TOKEN` environment variable.

In rclone, if `env_auth = true` is set, v1.57 will refer to `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` properly.

https://github.com/rclone/rclone/issues/5762
