### PR TITLE
add persistence annotation and selector.matchLabels

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 ### Added
   * If you want to save mysql backup to AWS S3, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` were the only options, but now you can use `AWS_SESSION_TOKEN` or `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE`
+ * Add `orchestrator.persistence.selector.matchLabels` and `orchestrator.persistence.annotations` for
+   persistence depolyment with constraints
  * Add `orchestrator.persistence.fsGroupWorkaroundEnabled` for persistent volume
    provisioners wich don't support fsGroup in security context (fixes #615)
  * Add `appSecretLabels`, `appSecretAnnotations`, `backupSecretLabels`, `backupSecretAnnotations` to provide 

--- a/deploy/charts/mysql-operator/templates/statefulset.yaml
+++ b/deploy/charts/mysql-operator/templates/statefulset.yaml
@@ -175,11 +175,22 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: data
+        {{- with .Values.orchestrator.persistence.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         accessModes: [ {{ .Values.orchestrator.persistence.accessMode }} ]
         resources:
           requests:
             storage: {{ .Values.orchestrator.persistence.size }}
+        {{- if .Values.orchestrator.persistence.selector }}
+        {{- with .Values.orchestrator.persistence.selector.matchLabels }}
+        selector:
+          matchLabels:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- end }}
       {{- if .Values.orchestrator.persistence.storageClass }}
       {{- if (eq "-" .Values.orchestrator.persistence.storageClass) }}
         storageClassName: ""

--- a/deploy/charts/mysql-operator/values.yaml
+++ b/deploy/charts/mysql-operator/values.yaml
@@ -140,6 +140,9 @@ orchestrator:
     ##   GKE, AWS & OpenStack)
     ##
     # storageClass: "-"
+    # annotations: {}
+    # selector:
+    #  matchLabels: {}
     accessMode: "ReadWriteOnce"
     size: 1Gi
     # inject an init container which properly sets the ownership for the orchestrator's data volume


### PR DESCRIPTION
This pull request adds the option to set persistence `annotation` and `selector.matchLabels` for some custom deployment scenarios.