### PR TITLE
test: fix mysqluser unit test

### DIFF
--- a/pkg/controller/mysqluser/mysqluser_controller_test.go
+++ b/pkg/controller/mysqluser/mysqluser_controller_test.go
@@ -538,6 +538,8 @@ var _ = Describe("MySQL user controller", func() {
 			})
 
 			It("doesn't remove the user finalizer and it tries to reconcile again", func() {
+				fakeSQL.AllowExtraCalls()
+
 				expectedQueryRunnerCall := func(query string, args ...interface{}) error {
 					Expect(query).To(Equal("DROP USER IF EXISTS ?@?;"))
 


### PR DESCRIPTION
Signed-off-by: cndoit18 <cndoit18@outlook.com>

The timing of the Reconcile trigger is uncertain and may result in more the number of `Reconcile` called than the number of `AddExpectedCalls` called, resulting in empty `expectedCalls`.

---
 - [ ] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
