### PR TITLE
Add pt-kill configuration to mysql-cluster chart

### DIFF
--- a/deploy/charts/mysql-cluster/templates/cluster.yaml
+++ b/deploy/charts/mysql-cluster/templates/cluster.yaml
@@ -71,3 +71,8 @@ spec:
   initFileExtraSQL:
     {{- toYaml .Values.initFileExtraSQL | nindent 6 }}
   {{- end }}
+
+  {{- if .Values.queryLimits }}
+  queryLimits:
+    {{ toYaml .Values.queryLimits | indent 4 }}
+  {{- end }}

--- a/deploy/charts/mysql-cluster/values.yaml
+++ b/deploy/charts/mysql-cluster/values.yaml
@@ -49,3 +49,12 @@ backupCredentials:
 
   # HTTP_URL: ?
 
+## For enabling and configuring pt-kill: https://www.percona.com/doc/percona-toolkit/LATEST/pt-kill.html
+#queryLimits:
+#  maxIdleTime: ...                # pt-kill --idle-time
+#  maxQueryTime: ...               # pt-kill --busy-time
+#  kill: oldest|all|all-but-oldest # pt-kill --victims
+#  killMode: query|connection      # pt-kill --kill-query or pt-kill --kill
+#  ignoreDb: []                    # pt-kill --ignore-db ...
+#  ignoreCommand: []               # pt-kill --ignore-command ...
+#  ignoreUser: []                  # pt-kill --ignore-user


### PR DESCRIPTION
closes/fixes #713

Adds `queryLimits` options to mysql-cluster chart to simplify pt-kill usage

---
 - [ ] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
