### PR TITLE
Use 1001 for mysql 8.0

### DIFF
--- a/examples/example-cluster.yaml
+++ b/examples/example-cluster.yaml
@@ -64,6 +64,7 @@ spec:
   #   priorityClassName:
   #   serviceAccountName: default
   #   # Use a initContainer to fix the permissons of a hostPath volume.
+  #   # If the version of mysql is 8.0, please change "999" to "1001"
   #   initContainers:
   #     - name: volume-permissions
   #       image: busybox

--- a/hack/development/Dockerfile.sidecar
+++ b/hack/development/Dockerfile.sidecar
@@ -32,8 +32,9 @@ RUN wget -nv https://github.com/ncw/rclone/releases/download/v${RCLONE_VERSION}/
 
 FROM debian:buster-slim as sidecar
 
-RUN groupadd -g 999 mysql
-RUN useradd -u 999 -r -g 999 -s /sbin/nologin \
+ARG USER_ID=999
+RUN groupadd -g ${USER_ID} mysql
+RUN useradd -u ${USER_ID} -r -g ${USER_ID} -s /sbin/nologin \
     -c "Default Application User" mysql
 
 RUN apt-get update \

--- a/images/mysql-operator-sidecar-5.7/Dockerfile
+++ b/images/mysql-operator-sidecar-5.7/Dockerfile
@@ -4,8 +4,9 @@
 
 FROM debian:buster-slim as sidecar
 
-RUN groupadd -g 999 mysql
-RUN useradd -u 999 -r -g 999 -s /sbin/nologin \
+ARG USER_ID=999
+RUN groupadd -g ${USER_ID} mysql
+RUN useradd -u ${USER_ID} -r -g ${USER_ID} -s /sbin/nologin \
     -c "Default Application User" mysql
 
 COPY rootfs/ /

--- a/images/mysql-operator-sidecar-8.0/Makefile
+++ b/images/mysql-operator-sidecar-8.0/Makefile
@@ -5,4 +5,4 @@ IMAGE = $(BUILD_REGISTRY)/mysql-operator-sidecar-8.0-$(ARCH)
 include ../../build/makelib/image.mk
 
 img.build:
-	@$(MAKE) -C ../mysql-operator-sidecar-5.7 IMAGE=$(IMAGE) BUILD_ARGS="--build-arg XTRABACKUP_PKG=percona-xtrabackup-80"
+	@$(MAKE) -C ../mysql-operator-sidecar-5.7 IMAGE=$(IMAGE) BUILD_ARGS="--build-arg USER_ID=1001 --build-arg XTRABACKUP_PKG=percona-xtrabackup-80"

--- a/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
+++ b/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
@@ -129,7 +129,7 @@ func (s *sfsSyncer) SyncFn(in runtime.Object) error {
 }
 
 func (s *sfsSyncer) ensurePodSpec() core.PodSpec {
-	fsGroup := int64(999) // mysql user UID
+	fsGroup := s.ensureUserID() // mysql user UID
 	return core.PodSpec{
 		InitContainers: s.ensureInitContainersSpec(),
 		Containers:     s.ensureContainersSpec(),
@@ -146,6 +146,15 @@ func (s *sfsSyncer) ensurePodSpec() core.PodSpec {
 		Tolerations:        s.cluster.Spec.PodSpec.Tolerations,
 		ServiceAccountName: s.cluster.Spec.PodSpec.ServiceAccountName,
 	}
+}
+
+func (s *sfsSyncer) ensureUserID() int64 {
+	if s.cluster.GetMySQLSemVer().Major == 5 {
+		return int64(constants.Mysql57UserID)
+	} else if s.cluster.GetMySQLSemVer().Major == 8 {
+		return int64(constants.Mysql8UserID)
+	}
+	return int64(constants.Mysql57UserID)
 }
 
 func (s *sfsSyncer) ensureContainer(name, image string, args []string) core.Container {

--- a/pkg/util/constants/constants.go
+++ b/pkg/util/constants/constants.go
@@ -22,6 +22,10 @@ const (
 	// MysqlPort is the default mysql port.
 	MysqlPort = 3306
 
+	// UserID should be selected according to different versions of mysql
+	Mysql57UserID = 999
+	Mysql8UserID  = 1001
+
 	// OrcTopologyDir path where orc conf secret is mounted
 	OrcTopologyDir = "/var/run/orc-topology"
 


### PR DESCRIPTION
fixes #742
---
Here is reason
https://github.com/bitpoke/mysql-operator/issues/742#issuecomment-965967360

1001 userID should be used for MySQL 8.0.

Mysql 8.0 can run normally on my machine after this change.

I don't know how to use The latest version of the `Makefile`. So I am still using `Makefile` of 0.4.0 version. If there is anything wrong with the modification of the `Makefile`, please call me.