### PR TITLE
Add metrics exporter image configuration in chart

### DIFF
--- a/deploy/charts/mysql-operator/README.md
+++ b/deploy/charts/mysql-operator/README.md
@@ -22,6 +22,8 @@ The following table contains the configuration parameters for mysql-operator and
 | `sidecar57.image.tag`           | Docker image tag for sidecar image for MySQL 5.7                                              | `latest`                                                |
 | `sidecar80.image.repository`    | Docker repository for sidecar image for MySQL 8.0                                             | `docker.io/bitpoke/mysql-operator-sidecar-8.0`          |
 | `sidecar80.image.tag`           | Docker image tag for sidecar image for MySQL 8.0                                              | `latest`                                                |
+| `metricsExporter.image.repository`    | Docker repository for MySQL metrics exporter                                            | `docker.io/prom/mysqld-exporter`                        |
+| `metricsExporter.image.tag`           | Docker image tag for MySQL metrics exporter                                             | `v0.13.0`                                                      |
 | `imagePullSecrets`              | Controller image pull secrets                                                                 | `[]`                                                    |
 | `extraEnv`                      | MySQL Operator controller extra environment variables                                         | `[]`                                                    |
 | `extraArgs`                     | MySQL Operator controller extra command line arguments                                        | `[]`                                                    |

--- a/deploy/charts/mysql-operator/templates/statefulset.yaml
+++ b/deploy/charts/mysql-operator/templates/statefulset.yaml
@@ -63,6 +63,9 @@ spec:
             {{- with .Values.sidecar80 }}
             - --sidecar-mysql8-image={{ .image.repository }}:{{ .image.tag | default $appVersion }}
             {{- end -}}
+            {{- with .Values.metricsExporter }}
+            - --metrics-exporter-image={{ .image.repository }}:{{ .image.tag }}
+            {{- end -}}
             {{- if .Values.watchNamespace }}
             - --namespace={{ .Values.watchNamespace }}
             {{- end }}

--- a/deploy/charts/mysql-operator/values.yaml
+++ b/deploy/charts/mysql-operator/values.yaml
@@ -21,6 +21,11 @@ sidecar80:
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
+metricsExporter:
+  image:
+    repository: docker.io/prom/mysqld-exporter
+    tag: "v0.13.0"
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Add metrics exporter image configuration in chart.

So that the user can customize the `--metrics-exporter-image`

---
 - [ ] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.
