### PR TITLE
feat: disable recurrent backup by set BackupSchedule to empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
  * `MysqlDatabase` `MysqlUser` Add delete policy
  * Add `PtHeartbeatResources` in `.Spec.PodSpec` to allow the user specifying resources for pt-heartbeat.
+ * Set `MysqlCluter.Spec.BackupSchedule` to empty string to disable recurrent backups
 ### Changed
  * Set default MySQL server version to `5.7.35`
 ### Removed

--- a/docs/cluster-recurrent-backups.md
+++ b/docs/cluster-recurrent-backups.md
@@ -42,3 +42,21 @@ Crontab takes 6 arguments from the traditional 5. The additional argument is a s
 | 0 0 0 * * 0   | @weekly                | Run once a week, midnight between Sat/Sun, 0 second  |
 | 0 0 0 * * *   | @daily (or @midnight)  | Run once a day, midnight, 0 second, 0 second                   |
 | 0 0 * * * *   | @hourly                | Run once an hour, beginning of hour, 0 second        |
+
+
+### Disable recurrent backups for MySQL cluster
+
+
+``` yaml
+apiVersion: mysql.presslabs.org/v1alpha1
+kind: MysqlCluster
+metadata:
+  name: my-cluster
+spec:
+  secretName: the-secret
+  
+  backupSchedule: ""  # set to empty string will disables recurrent backups
+  backupURL: gs://bucket_name/path/
+  backupSecretName: backup-secret
+  backupRemoteDeletePolicy: retain|delete
+```

--- a/pkg/controller/mysqlbackupcron/mysqlbackupcron_controller.go
+++ b/pkg/controller/mysqlbackupcron/mysqlbackupcron_controller.go
@@ -134,8 +134,11 @@ func (r *ReconcileMysqlBackup) Reconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{}, err
 	}
 
-	// if spec.backupScheduler is not set then don't do anything
+	// if Spec.BackupSchedule is not set, here are two cases:
+	// 	1. change to empty string, call unregisterCluster, it will remove the cron job
+	// 	2. remain empty string, call unregisterCluster, it will do nothing
 	if len(cluster.Spec.BackupSchedule) == 0 {
+		r.unregisterCluster(request.NamespacedName)
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/mysqlbackupcron/mysqlbackupcron_controller_test.go
+++ b/pkg/controller/mysqlbackupcron/mysqlbackupcron_controller_test.go
@@ -155,6 +155,19 @@ var _ = Describe("MysqlBackupCron controller", func() {
 			Expect(cron.Entries()).To(haveCronJob(cluster.Name, newSchedule))
 		})
 
+		It("should remove entry after set schedule to empty", func() {
+			// update cluster scheduler
+			cluster.Spec.BackupSchedule = ""
+
+			Expect(c.Update(context.TODO(), cluster)).To(Succeed())
+
+			// expect an reconcile event
+			Eventually(requests, timeout).Should(Receive(Equal(expectedRequest)))
+
+			// check cron entry for right scheduler
+			Expect(cron.Entries()).ToNot(haveCronJob(cluster.Name, schedule))
+		})
+
 		It("should be just one entry for a cluster", func() {
 			// update cluster spec
 			cluster.Spec.MysqlConf = map[string]intstr.IntOrString{


### PR DESCRIPTION
closes/fixes #841 

---
 - [x] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.
