### PR TITLE
fix: operator sa have no access to mysqlbackups/status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 ### Fixed
  * `orchestrator.secretName` is ignored in helm charts
+ * Operator service account have no access to update mysqlbackups/status
 
 ## [0.6.1] - 2021-12-22
 ### Changed

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -76,6 +76,7 @@ rules:
   - mysql.presslabs.org
   resources:
   - mysqlbackups
+  - mysqlbackups/status
   verbs:
   - create
   - delete

--- a/deploy/charts/mysql-operator/templates/clusterrole.yaml
+++ b/deploy/charts/mysql-operator/templates/clusterrole.yaml
@@ -76,6 +76,7 @@ rules:
     - mysql.presslabs.org
   resources:
     - mysqlbackups
+    - mysqlbackups/status
   verbs:
     - create
     - delete

--- a/pkg/controller/mysqlbackup/mysqlbackup_controller.go
+++ b/pkg/controller/mysqlbackup/mysqlbackup_controller.go
@@ -101,7 +101,7 @@ type ReconcileMysqlBackup struct {
 
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=mysql.presslabs.org,resources=mysqlbackups,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=mysql.presslabs.org,resources=mysqlbackups;mysqlbackups/status,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile reads that state of the cluster for a MysqlBackup object and makes changes based on the state read
 // and what is in the MysqlBackup.Spec


### PR DESCRIPTION
closes/fixes #844 

---
 - [x] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.
