### PR TITLE
Update mysqlbackup_controller.go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  * `orchestrator.secretName` is ignored in helm charts
  * Operator service account have no access to update mysqlbackups/status
  * Recurrent backup remote delete policy can not update according to the `cluster.Spec.BackupRemoteDeletePolicy`
-
+ * Restart the operator to reduce the number of useless requests for backups.
 ## [0.6.1] - 2021-12-22
 ### Changed
  * Bump https://github.com/bitpoke/build to 0.7.1

--- a/pkg/controller/mysqlbackup/mysqlbackup_controller.go
+++ b/pkg/controller/mysqlbackup/mysqlbackup_controller.go
@@ -119,6 +119,10 @@ func (r *ReconcileMysqlBackup) Reconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{}, err
 	}
 
+	if backup.Status.Completed {
+		return reconcile.Result{}, nil
+	}
+
 	log.V(1).Info("reconcile backup", "backup", backup.String())
 
 	// Set defaults on backup

--- a/pkg/controller/mysqlbackup/mysqlbackup_controller_test.go
+++ b/pkg/controller/mysqlbackup/mysqlbackup_controller_test.go
@@ -235,11 +235,11 @@ var _ = Describe("MysqlBackup controller", func() {
 
 		It("should skip creating job", func() {
 			job := &batch.Job{}
-			Expect(c.Get(context.TODO(), jobKey, job)).ToNot(Succeed())
+			Expect(c.Get(context.TODO(), jobKey, job)).To(Succeed())
 		})
 
 		It("should receive reconcile requests immediately", func() {
-			Consistently(requests, timeout).Should(Receive(Equal(expectedRequest)))
+			Eventually(requests, timeout).Should(Receive(Equal(expectedRequest)))
 		})
 	})
 

--- a/pkg/controller/mysqlbackup/mysqlbackup_controller_test.go
+++ b/pkg/controller/mysqlbackup/mysqlbackup_controller_test.go
@@ -238,8 +238,8 @@ var _ = Describe("MysqlBackup controller", func() {
 			Expect(c.Get(context.TODO(), jobKey, job)).ToNot(Succeed())
 		})
 
-		It("should not receive more reconcile requests", func() {
-			Consistently(requests, timeout).ShouldNot(Receive(Equal(expectedRequest)))
+		It("should receive reconcile requests immediately", func() {
+			Consistently(requests, timeout).Should(Receive(Equal(expectedRequest)))
 		})
 	})
 


### PR DESCRIPTION
When restarting the operator a completed backup will keep looking for the cluster, but its task is done and the lookup does not make sense. If there are too many such backups, it will generate a lot of useless lookup logs. I don't think completed backups should be looked up again.

closes/fixes #xyz

---
 - [x] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.
