### PR TITLE
Bump orchestrator version to 3.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  * Set `MysqlCluter.Spec.BackupSchedule` to empty string to disable recurrent backups
 ### Changed
  * Set default MySQL server version to `5.7.35`
+ * Bump Orchestrator to `3.2.6`
 ### Removed
 ### Fixed
  * `orchestrator.secretName` is ignored in helm charts

--- a/images/mysql-operator-orchestrator/Dockerfile
+++ b/images/mysql-operator-orchestrator/Dockerfile
@@ -13,7 +13,7 @@ RUN set -ex \
         tar -C /usr/local/bin -xzv
 
 RUN set -ex \
-    && export ORCHESTRATOR_VERSION=3.2.3 \
+    && export ORCHESTRATOR_VERSION=3.2.6 \
     && wget https://github.com/openark/orchestrator/releases/download/v${ORCHESTRATOR_VERSION}/orchestrator-${ORCHESTRATOR_VERSION}-linux-amd64.tar.gz -O- | \
         tar -C / -xzv
 


### PR DESCRIPTION
Current orchestrator version is 3.2.3 released on 04 Aug 2020. 
Nowadays Orchestrator is not in active developing. 
Latest minor version with fixes is v3.2.6 released on 27 Jul 2021. 

---
 - [x] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.
