### PR TITLE
[support only 1.21+] use policy/v1 for PodDisruptionBudget

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -151,7 +151,7 @@ steps:
   - gcloud container clusters create $CLUSTER_NAME
       --zone $GOOGLE_CLOUD_ZONE
       --preemptible
-      --cluster-version 1.19
+      --cluster-version 1.21
       --addons=GcePersistentDiskCsiDriver
       --monitoring=NONE
 

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ webroot/*
 _output
 
 build
+vendor

--- a/deploy/charts/mysql-operator/templates/pdb.yaml
+++ b/deploy/charts/mysql-operator/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.podDisruptionBudget.enabled (gt (int64 .Values.replicaCount) 1) }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "mysql-operator.fullname" . }}

--- a/pkg/controller/mysqlcluster/internal/syncer/pdb.go
+++ b/pkg/controller/mysqlcluster/internal/syncer/pdb.go
@@ -17,7 +17,7 @@ limitations under the License.
 package mysqlcluster
 
 import (
-	policy "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -30,7 +30,7 @@ import (
 
 // NewPDBSyncer returns the syncer for pdb
 func NewPDBSyncer(c client.Client, scheme *runtime.Scheme, cluster *mysqlcluster.MysqlCluster) syncer.Interface {
-	pdb := &policy.PodDisruptionBudget{
+	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cluster.GetNameForResource(mysqlcluster.PodDisruptionBudget),
 			Namespace: cluster.Namespace,

--- a/pkg/controller/mysqlcluster/mysqlcluster_controller.go
+++ b/pkg/controller/mysqlcluster/mysqlcluster_controller.go
@@ -23,7 +23,7 @@ import (
 	"github.com/presslabs/controller-util/syncer"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -104,7 +104,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	err = c.Watch(&source.Kind{Type: &policyv1beta1.PodDisruptionBudget{}}, &handler.EnqueueRequestForOwner{
+	err = c.Watch(&source.Kind{Type: &policyv1.PodDisruptionBudget{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &mysqlv1alpha1.MysqlCluster{},
 	})

--- a/pkg/controller/mysqlcluster/mysqlcluster_controller_test.go
+++ b/pkg/controller/mysqlcluster/mysqlcluster_controller_test.go
@@ -30,7 +30,7 @@ import (
 	"golang.org/x/net/context"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -156,7 +156,7 @@ var _ = Describe("MysqlCluster controller", func() {
 						Namespace: cluster.Namespace,
 					},
 				},
-				&policyv1beta1.PodDisruptionBudget{
+				&policyv1.PodDisruptionBudget{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      fmt.Sprintf("%s-mysql", name),
 						Namespace: cluster.Namespace,
@@ -212,7 +212,7 @@ var _ = Describe("MysqlCluster controller", func() {
 			Entry("reconciles the master service", "%s-mysql-master", &corev1.Service{}),
 			Entry("reconciles the operator secret", "%s-mysql-operated", &corev1.Secret{}),
 			Entry("reconciles the config map", "%s-mysql", &corev1.ConfigMap{}),
-			Entry("reconciles the pod disruption budget", "%s-mysql", &policyv1beta1.PodDisruptionBudget{}),
+			Entry("reconciles the pod disruption budget", "%s-mysql", &policyv1.PodDisruptionBudget{}),
 		)
 
 		Describe("the reconciler", func() {


### PR DESCRIPTION
Signed-off-by: hang.jiang <hang.jiang@daocloud.io>

closes/fixes #xyz

---
 - [x] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.
