### PR TITLE
style(log): level down the user creating log

### DIFF
--- a/pkg/controller/mysqluser/mysqluser_controller.go
+++ b/pkg/controller/mysqluser/mysqluser_controller.go
@@ -181,8 +181,8 @@ func (r *ReconcileMySQLUser) reconcileUserInDB(ctx context.Context, user *mysqlu
 		return errors.New("the MySQL user's password must not be empty")
 	}
 
-	// create/ update user in database
-	log.Info("creating mysql user", "key", user.GetKey(), "username", user.Spec.User, "cluster", user.GetClusterKey())
+	// reconcile user in database
+	log.V(1).Info("reconciling mysql user", "key", user.GetKey(), "username", user.Spec.User, "cluster", user.GetClusterKey())
 	if err := mysql.CreateUserIfNotExists(ctx, sql, user.Spec.User, password, user.Spec.AllowedHosts,
 		user.Spec.Permissions, user.Spec.ResourceLimits); err != nil {
 		return err


### PR DESCRIPTION
The user creating logs take up many space in the contianer log.
```
[root@demo-dev-master-01 ~]# kubectl -n mcamel-system logs mysql-operator-0 -c operator | wc -l
29666
[root@demo-dev-master-01 ~]# kubectl -n mcamel-system logs mysql-operator-0 -c operator | grep 'creating mysql user' | wc -l
18973
```

In my env, there are seven `MysqlUser` custom resource. The operator reconcile it every 2 minute. The annoy logs can not give useful message, but interference troubleshooting process

---
 - [x] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.
