### PR TITLE
Add RBAC permission on openshift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Set default MySQL server version to `5.7.35`
 * Bump Orchestrator to `3.2.6`
 * Change policy/v1beta1 to policy/v1
+* Add RBAC permissions when deploying on OpenShift
 
 ### Removed
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -76,6 +76,7 @@ rules:
   - mysql.presslabs.org
   resources:
   - mysqlbackups
+  - mysqlbackups/finalizers
   - mysqlbackups/status
   verbs:
   - create
@@ -89,6 +90,7 @@ rules:
   - mysql.presslabs.org
   resources:
   - mysqlclusters
+  - mysqlclusters/finalizers
   - mysqlclusters/status
   verbs:
   - create
@@ -102,6 +104,7 @@ rules:
   - mysql.presslabs.org
   resources:
   - mysqldatabases
+  - mysqldatabases/finalizers
   - mysqldatabases/status
   verbs:
   - create

--- a/deploy/charts/mysql-operator/templates/clusterrole.yaml
+++ b/deploy/charts/mysql-operator/templates/clusterrole.yaml
@@ -76,6 +76,7 @@ rules:
     - mysql.presslabs.org
   resources:
     - mysqlbackups
+    - mysqlbackups/finalizers
     - mysqlbackups/status
   verbs:
     - create
@@ -89,6 +90,7 @@ rules:
     - mysql.presslabs.org
   resources:
     - mysqlclusters
+    - mysqlclusters/finalizers
     - mysqlclusters/status
   verbs:
     - create
@@ -102,6 +104,7 @@ rules:
     - mysql.presslabs.org
   resources:
     - mysqldatabases
+    - mysqldatabases/finalizers
     - mysqldatabases/status
   verbs:
     - create

--- a/pkg/controller/mysqlbackup/mysqlbackup_controller.go
+++ b/pkg/controller/mysqlbackup/mysqlbackup_controller.go
@@ -101,7 +101,7 @@ type ReconcileMysqlBackup struct {
 
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=mysql.presslabs.org,resources=mysqlbackups;mysqlbackups/status,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=mysql.presslabs.org,resources=mysqlbackups;mysqlbackups/status;mysqlbackups/finalizers,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile reads that state of the cluster for a MysqlBackup object and makes changes based on the state read
 // and what is in the MysqlBackup.Spec

--- a/pkg/controller/mysqlcluster/mysqlcluster_controller.go
+++ b/pkg/controller/mysqlcluster/mysqlcluster_controller.go
@@ -136,7 +136,7 @@ type ReconcileMysqlCluster struct {
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=configmaps;secrets;services;events;jobs;pods;persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=mysql.presslabs.org,resources=mysqlclusters;mysqlclusters/status,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=mysql.presslabs.org,resources=mysqlclusters;mysqlclusters/status;mysqlclusters/finalizers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 

--- a/pkg/controller/mysqldatabase/db_controller.go
+++ b/pkg/controller/mysqldatabase/db_controller.go
@@ -65,7 +65,7 @@ type ReconcileMySQLDatabase struct {
 var _ reconcile.Reconciler = &ReconcileMySQLDatabase{}
 
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
-// +kubebuilder:rbac:groups=mysql.presslabs.org,resources=mysqldatabases;mysqldatabases/status,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=mysql.presslabs.org,resources=mysqldatabases;mysqldatabases/status;mysqldatabases/finalizers,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile reads that state of the cluster for a Wordpress object and makes changes based on the state read
 // and what is in the Wordpress.Spec


### PR DESCRIPTION
On openshift, the OwnerReferencesPermissionEnforcement admission controller is enabled by default(https://docs.openshift.com/container-platform/4.9/architecture/admission-plug-ins.html#admission-plug-ins-default_admission-plug-ins). We should add permission to operator according to https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement


---
 - [x] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.
