### PR TITLE
Allow orchestrator log level setting

### DIFF
--- a/hack/development/Dockerfile.orchestrator
+++ b/hack/development/Dockerfile.orchestrator
@@ -50,7 +50,7 @@ EXPOSE 3000 10008
 VOLUME [ "/var/lib/orchestrator" ]
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]
-CMD ["/usr/local/bin/orchestrator", "-quiet", "-config", "/etc/orchestrator/orchestrator.conf.json", "http"]
+CMD ["/usr/local/bin/orchestrator", "-config", "/etc/orchestrator/orchestrator.conf.json", "http"]
 
 # set expiration time for dev images
 # https://support.coreos.com/hc/en-us/articles/115001384693-Tag-Expiration

--- a/images/mysql-operator-orchestrator/Dockerfile
+++ b/images/mysql-operator-orchestrator/Dockerfile
@@ -36,4 +36,4 @@ ENTRYPOINT [ "/usr/local/bin/dockerize", \
              "-template", \
              "/usr/local/share/orchestrator/templates/orc-topology.cnf:/etc/orchestrator/orc-topology.cnf", \
              "--" ]
-CMD ["/usr/local/orchestrator/orchestrator", "-quiet", "-config", "/etc/orchestrator/orchestrator.conf.json", "http"]
+CMD ["/usr/local/orchestrator/orchestrator", "-config", "/etc/orchestrator/orchestrator.conf.json", "http"]


### PR DESCRIPTION
closes/fixes #xyz

For orchestrator, the `-quiet` flag will alway override value in config file, see:

https://github.com/openark/orchestrator/blob/c846d43668239cad384dc31b9255a3ade3a35001/go/cmd/orchestrator/main.go#L123C13-L126

In operator, the `-quiet` flag is setted by default. If we set `Debug: true` in orchstrator.json, that's not take effect.

---
 - [x] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.
