### PR TITLE
discovery new node

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -163,9 +163,8 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			}
 		}
 	}
-	err = mgr.Add(f)
 
-	return nil
+	return mgr.Add(f)
 }
 
 var _ reconcile.Reconciler = &ReconcileMysqlNode{}

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -114,6 +114,8 @@ func isRunning(obj runtime.Object) bool {
 var NodeGenericEvents = make(chan event.GenericEvent, 1024)
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
+//
+//nolint:gocyclo
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
 	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r})

--- a/pkg/controller/orchestrator/orchestrator_controller.go
+++ b/pkg/controller/orchestrator/orchestrator_controller.go
@@ -212,7 +212,7 @@ func (r *ReconcileMysqlCluster) Reconcile(ctx context.Context, request reconcile
 
 	// TODO no sync should be triggered if no replica is available
 
-	orcSyncer := NewOrcUpdater(cluster, r.recorder, r.orcClient)
+	orcSyncer := NewOrcUpdater(cluster, r.recorder, r.orcClient, r.Client)
 	if err := syncer.Sync(context.TODO(), orcSyncer, r.recorder); err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/orchestrator/orchestrator_reconcile.go
+++ b/pkg/controller/orchestrator/orchestrator_reconcile.go
@@ -19,25 +19,24 @@ package orchestrator
 import (
 	"context"
 	"fmt"
-	"github.com/bitpoke/mysql-operator/pkg/controller/node"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"regexp"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"strconv"
 	"strings"
 	"time"
 
+	api "github.com/bitpoke/mysql-operator/pkg/apis/mysql/v1alpha1"
+	"github.com/bitpoke/mysql-operator/pkg/controller/node"
+	"github.com/bitpoke/mysql-operator/pkg/internal/mysqlcluster"
+	orc "github.com/bitpoke/mysql-operator/pkg/orchestrator"
 	"github.com/go-logr/logr"
 	logf "github.com/presslabs/controller-util/log"
 	"github.com/presslabs/controller-util/syncer"
 	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
-
-	api "github.com/bitpoke/mysql-operator/pkg/apis/mysql/v1alpha1"
-	"github.com/bitpoke/mysql-operator/pkg/internal/mysqlcluster"
-	orc "github.com/bitpoke/mysql-operator/pkg/orchestrator"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
 const (

--- a/pkg/controller/orchestrator/orchestrator_reconcile.go
+++ b/pkg/controller/orchestrator/orchestrator_reconcile.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bitpoke/mysql-operator/pkg/controller/node"
 	"github.com/go-logr/logr"
 	logf "github.com/presslabs/controller-util/log"
 	"github.com/presslabs/controller-util/syncer"
@@ -36,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	api "github.com/bitpoke/mysql-operator/pkg/apis/mysql/v1alpha1"
+	"github.com/bitpoke/mysql-operator/pkg/controller/node"
 	"github.com/bitpoke/mysql-operator/pkg/internal/mysqlcluster"
 	orc "github.com/bitpoke/mysql-operator/pkg/orchestrator"
 )

--- a/pkg/controller/orchestrator/orchestrator_reconcile.go
+++ b/pkg/controller/orchestrator/orchestrator_reconcile.go
@@ -305,6 +305,7 @@ func (ou *orcUpdater) updateClusterFailoverInProgressStatus(master *orc.Instance
 
 // updateNodesInOrc is the functions that tries to register
 // unregistered nodes and to remove nodes that does not exists.
+// nolint:gocyclo
 func (ou *orcUpdater) updateNodesInOrc(instances InstancesSet) (InstancesSet, []orc.InstanceKey, []orc.InstanceKey) {
 	var (
 		// hosts that should be discovered

--- a/pkg/controller/orchestrator/orchestrator_reconcile.go
+++ b/pkg/controller/orchestrator/orchestrator_reconcile.go
@@ -329,6 +329,9 @@ func (ou *orcUpdater) updateNodesInOrc(instances InstancesSet) (InstancesSet, []
 				}
 				shouldDiscover = append(shouldDiscover, hostKey)
 				go func(i int) {
+					if ou.client == nil {
+						return
+					}
 					// check if the pod is running
 					// if pod is running, we should gen a event to let the replica reconnect to the master
 					pod := &core.Pod{

--- a/pkg/controller/orchestrator/orchestrator_reconcile.go
+++ b/pkg/controller/orchestrator/orchestrator_reconcile.go
@@ -24,10 +24,7 @@ import (
 	"strings"
 	"time"
 
-	api "github.com/bitpoke/mysql-operator/pkg/apis/mysql/v1alpha1"
 	"github.com/bitpoke/mysql-operator/pkg/controller/node"
-	"github.com/bitpoke/mysql-operator/pkg/internal/mysqlcluster"
-	orc "github.com/bitpoke/mysql-operator/pkg/orchestrator"
 	"github.com/go-logr/logr"
 	logf "github.com/presslabs/controller-util/log"
 	"github.com/presslabs/controller-util/syncer"
@@ -37,6 +34,10 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	api "github.com/bitpoke/mysql-operator/pkg/apis/mysql/v1alpha1"
+	"github.com/bitpoke/mysql-operator/pkg/internal/mysqlcluster"
+	orc "github.com/bitpoke/mysql-operator/pkg/orchestrator"
 )
 
 const (

--- a/pkg/controller/orchestrator/orchestrator_reconcile_test.go
+++ b/pkg/controller/orchestrator/orchestrator_reconcile_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Orchestrator reconciler", func() {
 			},
 		})
 
-		orcSyncer = NewOrcUpdater(cluster, rec, orcClient)
+		orcSyncer = NewOrcUpdater(cluster, rec, orcClient, nil)
 	})
 
 	When("cluster does not exists in orchestrator", func() {
@@ -372,7 +372,7 @@ var _ = Describe("Orchestrator reconciler", func() {
 		)
 
 		BeforeEach(func() {
-			updater = NewOrcUpdater(cluster, rec, orcClient).(*orcUpdater)
+			updater = NewOrcUpdater(cluster, rec, orcClient, nil).(*orcUpdater)
 			// set cluster on readonly, master should be in read only state
 			orcClient.AddInstance(orc.Instance{
 				ClusterName: cluster.GetClusterAlias(),
@@ -564,7 +564,7 @@ var _ = Describe("Orchestrator reconciler", func() {
 		)
 
 		BeforeEach(func() {
-			updater = NewOrcUpdater(cluster, rec, orcClient).(*orcUpdater)
+			updater = NewOrcUpdater(cluster, rec, orcClient, nil).(*orcUpdater)
 			// set cluster on readonly, master should be in read only state
 			orcClient.AddInstance(orc.Instance{
 				ClusterName: cluster.GetClusterAlias(),

--- a/pkg/internal/mysqlcluster/mysqlcluster.go
+++ b/pkg/internal/mysqlcluster/mysqlcluster.go
@@ -57,7 +57,7 @@ func (c *MysqlCluster) Unwrap() *api.MysqlCluster {
 }
 
 // GetLabels returns cluster labels
-func (c *MysqlCluster) GetLabels() labels.Set {
+func (c *MysqlCluster) GetLabels() map[string]string {
 
 	instance := c.Name
 	if inst, ok := c.Annotations["app.kubernetes.io/instance"]; ok {


### PR DESCRIPTION

When we found that a mysql pod was isolated and was able to switch normally. But the network recovery will not automatically append to the slave instance.
Because there is no change in this pod when the network is restored, no update or create will be triggered and the status is normal. It will not allow the operator to automatically create the master mechanism.
This is the fix for that.

 - [ ] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.
