### PR TITLE
Discovery new node

### DIFF
--- a/pkg/controller/orchestrator/orchestrator_controller.go
+++ b/pkg/controller/orchestrator/orchestrator_controller.go
@@ -212,7 +212,7 @@ func (r *ReconcileMysqlCluster) Reconcile(ctx context.Context, request reconcile
 
 	// TODO no sync should be triggered if no replica is available
 
-	orcSyncer := NewOrcUpdater(cluster, r.recorder, r.orcClient)
+	orcSyncer := NewOrcUpdater(cluster, r.recorder, r.orcClient, r.Client)
 	if err := syncer.Sync(context.TODO(), orcSyncer, r.recorder); err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/orchestrator/orchestrator_reconcile.go
+++ b/pkg/controller/orchestrator/orchestrator_reconcile.go
@@ -329,7 +329,7 @@ func (ou *orcUpdater) updateNodesInOrc(instances InstancesSet) (InstancesSet, []
 				// When a pod is detected that has not changed and needs to be joined
 				// we restart it to trigger a state change of the pod and rejoin the cluster.
 				podName := fmt.Sprintf("%s-%d", ou.cluster.GetNameForResource(mysqlcluster.StatefulSet), i)
-				err := ou.restartPod(ou.cluster.Namespace, fmt.Sprintf("%s-%d", podName))
+				err := ou.restartPod(ou.cluster.Namespace, podName)
 				if err != nil {
 					ou.log.Error(err, "restart failed:", "pod", podName)
 				}
@@ -383,7 +383,13 @@ func (ou *orcUpdater) restartPod(nameSpace, podName string) error {
 				readyNum++
 			}
 		}
-		if readyNum == 3 {
+		if pod.Labels["role"] == "replica" {
+			readyNum++
+		}
+		if pod.Labels["healthy"] == "no" {
+			readyNum++
+		}
+		if readyNum == 5 {
 			return ou.client.Delete(context.Background(), pod)
 		}
 	}

--- a/pkg/controller/orchestrator/orchestrator_reconcile_test.go
+++ b/pkg/controller/orchestrator/orchestrator_reconcile_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Orchestrator reconciler", func() {
 			},
 		})
 
-		orcSyncer = NewOrcUpdater(cluster, rec, orcClient)
+		orcSyncer = NewOrcUpdater(cluster, rec, orcClient, nil)
 	})
 
 	When("cluster does not exists in orchestrator", func() {
@@ -372,7 +372,7 @@ var _ = Describe("Orchestrator reconciler", func() {
 		)
 
 		BeforeEach(func() {
-			updater = NewOrcUpdater(cluster, rec, orcClient).(*orcUpdater)
+			updater = NewOrcUpdater(cluster, rec, orcClient, nil).(*orcUpdater)
 			// set cluster on readonly, master should be in read only state
 			orcClient.AddInstance(orc.Instance{
 				ClusterName: cluster.GetClusterAlias(),
@@ -564,7 +564,7 @@ var _ = Describe("Orchestrator reconciler", func() {
 		)
 
 		BeforeEach(func() {
-			updater = NewOrcUpdater(cluster, rec, orcClient).(*orcUpdater)
+			updater = NewOrcUpdater(cluster, rec, orcClient, nil).(*orcUpdater)
 			// set cluster on readonly, master should be in read only state
 			orcClient.AddInstance(orc.Instance{
 				ClusterName: cluster.GetClusterAlias(),


### PR DESCRIPTION
closes/fixes #xyz

When we found that a mysql pod was isolated and was able to switch normally. But the network recovery will not automatically append to the slave instance.
Because there is no change in this pod when the network is restored, no update or create will be triggered and the status is normal. It will not allow the operator to automatically create the master mechanism.
This is the fix for that.

---
 - [ ] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.
