### PR TITLE
Add optional field to keep pvc after cluster been deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+* Add `KeepAfterDelete` in `.Spec.VolumeSpec` to keep pvc after mysql cluster been deleted.
+
 ### Changed
 ### Removed
 ### Fixed

--- a/config/crd/bases/mysql.presslabs.org_mysqlclusters.yaml
+++ b/config/crd/bases/mysql.presslabs.org_mysqlclusters.yaml
@@ -3827,6 +3827,9 @@ spec:
                       required:
                         - path
                       type: object
+                    keepAfterDelete:
+                      description: KeepAfterDelete specifies whether the PVC should be kept after the MysqlCluster is deleted.
+                      type: boolean
                     persistentVolumeClaim:
                       description: PersistentVolumeClaim to specify PVC spec for the volume for mysql data. It has the highest level of precedence, followed by HostPath and EmptyDir. And represents the PVC specification.
                       properties:

--- a/deploy/charts/mysql-operator/crds/mysql.presslabs.org_mysqlclusters.yaml
+++ b/deploy/charts/mysql-operator/crds/mysql.presslabs.org_mysqlclusters.yaml
@@ -3828,6 +3828,9 @@ spec:
                       required:
                         - path
                       type: object
+                    keepAfterDelete:
+                      description: KeepAfterDelete specifies whether the PVC should be kept after the MysqlCluster is deleted.
+                      type: boolean
                     persistentVolumeClaim:
                       description: PersistentVolumeClaim to specify PVC spec for the volume for mysql data. It has the highest level of precedence, followed by HostPath and EmptyDir. And represents the PVC specification.
                       properties:

--- a/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
+++ b/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
@@ -243,6 +243,10 @@ type VolumeSpec struct {
 	// EmptyDir. And represents the PVC specification.
 	// +optional
 	PersistentVolumeClaim *core.PersistentVolumeClaimSpec `json:"persistentVolumeClaim,omitempty"`
+
+	// KeepAfterDelete specifies whether the PVC should be kept after the MysqlCluster is deleted.
+	// +optional
+	KeepAfterDelete bool `json:"keepAfterDelete,omitempty"`
 }
 
 // QueryLimits represents the pt-kill parameters, more info can be found

--- a/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
+++ b/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
@@ -581,7 +581,7 @@ func (s *sfsSyncer) ensureVolumeClaimTemplates(in []core.PersistentVolumeClaim) 
 
 	data.Name = dataVolumeName
 
-	if initPvc {
+	if initPvc && !s.cluster.Spec.VolumeSpec.KeepAfterDelete {
 		// This can be set only when creating new PVC. It ensures that PVC can be
 		// terminated after deleting parent MySQL cluster
 		trueVar := true


### PR DESCRIPTION
closes/fixes https://github.com/bitpoke/mysql-operator/issues/892

---
 - [x] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.
