### PR TITLE
fix queryLimits indentation

### DIFF
--- a/deploy/charts/mysql-cluster/templates/cluster.yaml
+++ b/deploy/charts/mysql-cluster/templates/cluster.yaml
@@ -74,5 +74,5 @@ spec:
 
   {{- if .Values.queryLimits }}
   queryLimits:
-    {{ toYaml .Values.queryLimits | indent 4 }}
+    {{- toYaml .Values.queryLimits | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
Fixes incorrect indentation for queryLimits values in Helm chart template

---
 - [ ] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.
