### PR TITLE
Change headless svc name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Add `KeepAfterDelete` in `.Spec.VolumeSpec` to keep pvc after mysql cluster been deleted.
 
 ### Changed
+* Changed headless svc name to a templated name that includes the mysql cluster name
+
 ### Removed
 ### Fixed
 

--- a/pkg/internal/mysqlcluster/mysqlcluster.go
+++ b/pkg/internal/mysqlcluster/mysqlcluster.go
@@ -30,11 +30,6 @@ import (
 	"github.com/bitpoke/mysql-operator/pkg/util/constants"
 )
 
-const (
-	// HeadlessSVCName is the name of the headless service that is commonly used for all clusters
-	HeadlessSVCName = "mysql"
-)
-
 // MysqlCluster is the wrapper for api.MysqlCluster type
 type MysqlCluster struct {
 	*api.MysqlCluster
@@ -137,7 +132,7 @@ func GetNameForResource(name ResourceName, clusterName string) string {
 	case HealthyReplicasService:
 		return fmt.Sprintf("%s-mysql-replicas", clusterName)
 	case HeadlessSVC:
-		return HeadlessSVCName
+		return fmt.Sprintf("%s-mysql-headless", clusterName)
 	case OldHeadlessSVC:
 		return fmt.Sprintf("%s-mysql-nodes", clusterName)
 	case Secret:


### PR DESCRIPTION
Change the Headless Service Name to Template-Generated Name


---
 - [x] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.

_Overview_:
This pull request introduces a modification to the project that updates the naming convention of the Headless Service (SVC). Currently, the Headless Service name is hardcoded using a constant-defined name, which can lead to naming conflicts and limitations in certain scenarios. To address this issue and improve flexibility, this PR proposes changing the Headless Service name to be dynamically generated using a template.

_Motivation_:
The primary motivation behind this change is to enhance the scalability and maintainability of the project by removing the constraints imposed by a static, constant-defined name. The template-generated name will allow for more dynamic and context-aware naming of the Headless Service, making it easier to manage in various deployment environments and configurations.