### PR TITLE
Support default resource of init container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 * Add `KeepAfterDelete` in `.Spec.VolumeSpec` to keep pvc after mysql cluster been deleted.
+* Add default resource to init container.
 
 ### Changed
 ### Removed

--- a/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
+++ b/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
@@ -351,6 +351,7 @@ func (s *sfsSyncer) ensureInitContainersSpec() []core.Container {
 		s.cluster.GetSidecarImage(),
 		[]string{"clone-and-init"},
 	)
+	cloneInit.Resources = s.ensureResources(containerCloneAndInitName)
 	initCs = append(initCs, cloneInit)
 
 	// add init container for MySQL if docker image supports this
@@ -676,7 +677,7 @@ func (s *sfsSyncer) ensureResources(name string) core.ResourceRequirements {
 	case containerExporterName:
 		return s.cluster.Spec.PodSpec.MetricsExporterResources
 
-	case containerMySQLInitName, containerMysqlName:
+	case containerMySQLInitName, containerCloneAndInitName, containerMysqlName:
 		return s.cluster.Spec.PodSpec.Resources
 
 	case containerHeartBeatName:


### PR DESCRIPTION
ISSUE description:
1. create ns resource quota:
```
apiVersion: v1
kind: ResourceQuota
metadata:
  name: quota-mcamel-system
  namespace: mcamel-system
spec:
  hard:
    requests.cpu: "1"
    requests.memory: "1Gi"
    limits.cpu: "10"
    limits.memory: "20Gi"
```
2. create mysql cluster

pod does not craeted as expected, statefulset event shows:
```
Events:
   Type     Reason        Age                 From                    Message
   ----     ------        ----                ----                    -------
   Warning  FailedCreate  10m (x21 over 65m)  statefulset-controller  create Pod wy-mysql-1-mysql-0 in StatefulSet wy-mysql-1-mysql failed error: pods "wy-mysql-1-mysql-0" is forbidden: failed quota: quota-mcamel-system: must specify limits.cpu,limits.memory,requests.cpu,requests.memory
```

---
 - [x] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.
