### PR TITLE
Add backup resources and labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 * Add `KeepAfterDelete` in `.Spec.VolumeSpec` to keep pvc after mysql cluster been deleted.
 * Add default resource to init container.
+* Add `MysqlCluster.Spec.BackupResources` to allow the user specifying resources for backup job container.
+* Add `MysqlCluster.Spec.BackupLabels` to allow the user specifying labels for backup job pods.
 
 ### Changed
 ### Removed

--- a/config/crd/bases/mysql.presslabs.org_mysqlclusters.yaml
+++ b/config/crd/bases/mysql.presslabs.org_mysqlclusters.yaml
@@ -54,9 +54,36 @@ spec:
                   items:
                     type: string
                   type: array
+                backupLabels:
+                  additionalProperties:
+                    type: string
+                  description: BackupLabels set labels to backup pods
+                  type: object
                 backupRemoteDeletePolicy:
                   description: BackupRemoteDeletePolicy the deletion policy that specify how to treat the data from remote storage. By default it's used softDelete.
                   type: string
+                backupResources:
+                  description: BackupResources sets resources to backup pod container
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
                 backupSchedule:
                   description: Specify under crontab format interval to take backups leave it empty to deactivate the backup process Defaults to ""
                   type: string

--- a/deploy/charts/mysql-cluster/templates/cluster.yaml
+++ b/deploy/charts/mysql-cluster/templates/cluster.yaml
@@ -51,6 +51,14 @@ spec:
   {{- if .Values.backupScheduleJobsHistoryLimit }}
   backupScheduleJobsHistoryLimit: {{ .Values.backupScheduleJobsHistoryLimit }}
   {{- end }}
+  {{- if .Values.backupResources }}
+  backupResources:
+    {{- toYaml .Values.backupResources | nindent 4 }}
+  {{- end }}
+  {{- if .Values.backupLabels }}
+  backupLabels:
+    {{- toYaml .Values.backupLabels | nindent 4 }}
+  {{- end }}
 
   {{- if .Values.mysqlConf }}
   mysqlConf:

--- a/deploy/charts/mysql-cluster/values.yaml
+++ b/deploy/charts/mysql-cluster/values.yaml
@@ -34,6 +34,8 @@ backupSecretName:
 backupRemoteDeletePolicy:
 # backupSecretLabels: {}
 # backupSecretAnnotations: {}
+# backupResources: {}
+# backupLabels: {}
 backupCredentials:
   # use s3 https://rclone.org/s3/
   # S3_PROVIDER: ?             # like: AWS, Minio, Ceph, and so on

--- a/deploy/charts/mysql-operator/crds/mysql.presslabs.org_mysqlclusters.yaml
+++ b/deploy/charts/mysql-operator/crds/mysql.presslabs.org_mysqlclusters.yaml
@@ -55,9 +55,36 @@ spec:
                   items:
                     type: string
                   type: array
+                backupLabels:
+                  additionalProperties:
+                    type: string
+                  description: BackupLabels set labels to backup pods
+                  type: object
                 backupRemoteDeletePolicy:
                   description: BackupRemoteDeletePolicy the deletion policy that specify how to treat the data from remote storage. By default it's used softDelete.
                   type: string
+                backupResources:
+                  description: BackupResources sets resources to backup pod container
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      type: object
+                  type: object
                 backupSchedule:
                   description: Specify under crontab format interval to take backups leave it empty to deactivate the backup process Defaults to ""
                   type: string

--- a/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
+++ b/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
@@ -95,6 +95,14 @@ type MysqlClusterSpec struct {
 	// +optional
 	BackupScheduleJobsHistoryLimit *int `json:"backupScheduleJobsHistoryLimit,omitempty"`
 
+	// BackupResources sets resources to backup pod container
+	// +optional
+	BackupResources core.ResourceRequirements `json:"backupResources,omitempty"`
+
+	// BackupLabels set labels to backup pods
+	// +optional
+	BackupLabels map[string]string `json:"backupLabels,omitempty"`
+
 	// A map[string]string that will be passed to my.cnf file.
 	// +optional
 	MysqlConf MysqlConf `json:"mysqlConf,omitempty"`
@@ -371,7 +379,6 @@ type MysqlClusterStatus struct {
 // +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".spec.replicas",description="The number of desired nodes"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:shortName=mysql
-//
 type MysqlCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -382,7 +389,6 @@ type MysqlCluster struct {
 
 // MysqlClusterList contains a list of MysqlCluster
 // +kubebuilder:object:root=true
-//
 type MysqlClusterList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/apis/mysql/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/mysql/v1alpha1/zz_generated.deepcopy.go
@@ -259,6 +259,14 @@ func (in *MysqlClusterSpec) DeepCopyInto(out *MysqlClusterSpec) {
 		*out = new(int)
 		**out = **in
 	}
+	in.BackupResources.DeepCopyInto(&out.BackupResources)
+	if in.BackupLabels != nil {
+		in, out := &in.BackupLabels, &out.BackupLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.MysqlConf != nil {
 		in, out := &in.MysqlConf, &out.MysqlConf
 		*out = make(MysqlConf, len(*in))

--- a/pkg/controller/mysqlbackup/internal/syncer/job.go
+++ b/pkg/controller/mysqlbackup/internal/syncer/job.go
@@ -84,6 +84,7 @@ func (s *jobSyncer) SyncFn() error {
 		"cluster": s.backup.Spec.ClusterName,
 	}
 
+	s.job.Spec.Template.Labels = s.cluster.Spec.BackupLabels
 	s.job.Spec.Template.Spec = s.ensurePodSpec(s.job.Spec.Template.Spec)
 	return nil
 }
@@ -129,6 +130,7 @@ func (s *jobSyncer) ensurePodSpec(in core.PodSpec) core.PodSpec {
 	in.Containers[0].Name = "backup"
 	in.Containers[0].Image = s.cluster.GetSidecarImage()
 	in.Containers[0].ImagePullPolicy = s.opt.ImagePullPolicy
+	in.Containers[0].Resources = s.cluster.Spec.BackupResources
 	in.Containers[0].Args = []string{
 		"take-backup-to",
 		s.getBackupCandidate(),


### PR DESCRIPTION

- Add `MysqlCluster.Spec.BackupResources` to allow the user specifying resources for backup job container.
- Add `MysqlCluster.Spec.BackupLabels` to allow the user specifying labels for backup job pods.

---
 - [x] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.
