### PR TITLE
Avoid set read_only conflict when graceful takeover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 ### Removed
 ### Fixed
+* Avoid set read_only conflict when graceful takeover
 
 ## [0.6.3] - 2023-05-22
 

--- a/deploy/charts/mysql-operator/values.yaml
+++ b/deploy/charts/mysql-operator/values.yaml
@@ -255,7 +255,9 @@ orchestrator:
       - "/usr/local/bin/orc-helper event -w '{failureClusterAlias}' 'OrcFailureDetection' 'Failure: {failureType}, failed host: {failedHost}, lost replcas: {lostReplicas}' || true"
       - "/usr/local/bin/orc-helper failover-in-progress '{failureClusterAlias}' '{failureDescription}' || true"
 
-    # PreGracefulTakeoverProcesses:
+    PreGracefulTakeoverProcesses:
+      - "/usr/local/bin/orc-helper failover-in-progress '{failureClusterAlias}' '{failureDescription}' || true"
+
     PreFailoverProcesses:
       # as backup in case the first request fails
       - "/usr/local/bin/orc-helper failover-in-progress '{failureClusterAlias}' '{failureDescription}' || true"


### PR DESCRIPTION
closes/fixes #922 

---
 - [x] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.
