### PR TITLE
Run e2e tests with Kubernetes 1.28

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -151,7 +151,7 @@ steps:
   - gcloud container clusters create $CLUSTER_NAME
       --zone $GOOGLE_CLOUD_ZONE
       --preemptible
-      --cluster-version 1.25
+      --cluster-version 1.28
       --addons=GcePersistentDiskCsiDriver
       --monitoring=NONE
 


### PR DESCRIPTION
closes/fixes https://ci.bitpoke.io/bitpoke/mysql-operator/470/2/3

ref: https://github.com/GoogleCloudPlatform/magic-modules/pull/10945

---
 - [ ] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.
