### PR TITLE
Support custom sidecar image in MysqlCluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 * Add `KeepAfterDelete` in `.Spec.VolumeSpec` to keep pvc after mysql cluster been deleted.
 * Add default resource to init container.
+* Add SidecarImage fields to `.Spec` to allow specifying custom sidecar image.
 
 ### Changed
 ### Removed

--- a/config/crd/bases/mysql.presslabs.org_mysqlclusters.yaml
+++ b/config/crd/bases/mysql.presslabs.org_mysqlclusters.yaml
@@ -3791,6 +3791,9 @@ spec:
                 serverIDOffset:
                   description: Set a custom offset for Server IDs.  ServerID for each node will be the index of the statefulset, plus offset
                   type: integer
+                sidecarImage:
+                  description: To specify the image that will be used for sidecar container. It will override --sidecar-image or --sidecar-mysql8-image flags.
+                  type: string
                 tmpfsSize:
                   anyOf:
                     - type: integer

--- a/deploy/charts/mysql-operator/crds/mysql.presslabs.org_mysqlclusters.yaml
+++ b/deploy/charts/mysql-operator/crds/mysql.presslabs.org_mysqlclusters.yaml
@@ -3792,6 +3792,9 @@ spec:
                 serverIDOffset:
                   description: Set a custom offset for Server IDs.  ServerID for each node will be the index of the statefulset, plus offset
                   type: integer
+                sidecarImage:
+                  description: To specify the image that will be used for sidecar container. It will override --sidecar-image or --sidecar-mysql8-image flags.
+                  type: string
                 tmpfsSize:
                   anyOf:
                     - type: integer

--- a/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
+++ b/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
@@ -57,6 +57,11 @@ type MysqlClusterSpec struct {
 	// +optional
 	Image string `json:"image,omitempty"`
 
+	// To specify the image that will be used for sidecar container.
+	// It will override --sidecar-image or --sidecar-mysql8-image flags.
+	// +optional
+	SidecarImage string `json:"sidecarImage,omitempty"`
+
 	// A bucket URL that contains a xtrabackup to initialize the mysql database.
 	// +optional
 	InitBucketURL string `json:"initBucketURL,omitempty"`

--- a/pkg/internal/mysqlcluster/mysqlcluster.go
+++ b/pkg/internal/mysqlcluster/mysqlcluster.go
@@ -268,13 +268,14 @@ func (c *MysqlCluster) GetNamespacedName() types.NamespacedName {
 
 // GetSidecarImage selects the sidecar docker image based on mysql version
 func (c *MysqlCluster) GetSidecarImage() string {
-	// decide the sidecar image based on mysql version
-	sidecarImage := options.GetOptions().SidecarMysql57Image
-	if c.GetMySQLSemVer().Major == 8 {
-		sidecarImage = options.GetOptions().SidecarMysql8Image
+	if c.Spec.SidecarImage != "" {
+		return c.Spec.SidecarImage
 	}
-
-	return sidecarImage
+	// decide the sidecar image based on mysql version
+	if c.GetMySQLSemVer().Major == 8 {
+		return options.GetOptions().SidecarMysql8Image
+	}
+	return options.GetOptions().SidecarMysql57Image
 }
 
 // IsClusterReady checks if the cluster is ready or not.


### PR DESCRIPTION
In my use case, I need to run different MySQL 8 versions, such as MySQL 8.0.29 and MySQL 8.0.37. However, as a sidecar with MySQL, the xtrabackup is not compatible with this version. This means that different MySQL versions must run with different xtrabackup images; otherwise, we will receive error logs from xtrabackup, such as:

<img width="1637" alt="截屏2024-08-08 15 06 39" src="https://github.com/user-attachments/assets/df6ae542-038e-45df-90cb-15e61d8ee85e">

- https://docs.percona.com/percona-xtrabackup/8.0/release-notes/8.0/8.0.29-22.0.html
- https://docs.percona.com/percona-xtrabackup/8.0/release-notes/8.0/8.0.34-29.0.html

---
 - [x] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.
